### PR TITLE
Fix logrotate config

### DIFF
--- a/support/kellner.logrotate
+++ b/support/kellner.logrotate
@@ -1,4 +1,5 @@
 /var/log/kellner.log {
+    su root root
     daily
     missingok
     rotate 30
@@ -6,5 +7,5 @@
     notifempty
     sharedscripts
     postrotate
-        pkill -f kellner -s SIGUSR1
+        pkill -f kellner -SIGUSR1
     endscript


### PR DESCRIPTION
- `su` directive needed if log directory is not owned by root/root
- pkill's `-s` parameter is NOT the signal, fix that
  
  modified:   kellner.logrotate
